### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
+  - 7.1
+  - 7.2
+  - 7.3
 
-before_script: composer install --dev
+before_script: composer install
+
+script:
+  - bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
     ],
     "license": "MIT",
     "require": {
-        "php": ">=5.3.0"
+        "php": "^7.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "~3.7"
+        "phpunit/phpunit": "^7.0"
     },
     "authors": [
         {
@@ -23,8 +23,13 @@
         }
     ],
     "autoload": {
-        "psr-0": {
-            "": "src/"
+        "psr-4": {
+            "Elnur\\Era\\": "src/Elnur/Era/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Elnur\\Era\\": "test/Elnur/Era/"
         }
     },
     "config": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,7 @@
     bootstrap="./vendor/autoload.php"
 >
     <testsuites>
-        <testsuite>
+        <testsuite name="era tests">
             <directory>test</directory>
         </testsuite>
     </testsuites>

--- a/src/Elnur/Era/AgeCalculator.php
+++ b/src/Elnur/Era/AgeCalculator.php
@@ -23,7 +23,6 @@
 namespace Elnur\Era;
 
 use DateTime;
-use Elnur\Era\CalendarInterface;
 
 class AgeCalculator implements AgeCalculatorInterface
 {

--- a/test/Elnur/Era/AgeCalculatorTest.php
+++ b/test/Elnur/Era/AgeCalculatorTest.php
@@ -23,15 +23,15 @@
 namespace Elnur\Era;
 
 use DateTime;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class AgeCalculatorTest extends PHPUnit_Framework_TestCase
+class AgeCalculatorTest extends TestCase
 {
     public function testAge()
     {
         $now = new DateTime('2007-05-31');
 
-        $calendar = $this->getMockForAbstractClass('Elnur\Era\CalendarInterface');
+        $calendar = $this->getMockForAbstractClass(CalendarInterface::class);
         $calendar
             ->expects($this->any())
             ->method('now')

--- a/test/Elnur/Era/CalendarTest.php
+++ b/test/Elnur/Era/CalendarTest.php
@@ -23,13 +23,17 @@
 namespace Elnur\Era;
 
 use DateTime;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class CalendarTest extends PHPUnit_Framework_TestCase
+class CalendarTest extends TestCase
 {
     public function testNow()
     {
+        $dateFormat = 'Y-m-d H:m';
         $calendar = new Calendar;
-        $this->assertEquals(new DateTime, $calendar->now());
+        $now = new DateTime;
+
+        $this->assertInstanceOf(DateTime::class, $calendar->now());
+        $this->assertEquals($now->format($dateFormat), $calendar->now()->format($dateFormat));
     }
 }


### PR DESCRIPTION
# Changed log
- Since the `php-7.1` has been stable support for official PHP team.
Using this version requirement at least for this package.
- Using the class-based `PHPUnit` namespace for supporting latest `PHPUnit` version.
- To do unit test about `Calendar::now` method in advanced, using the `DateTime::format` to assert that the specific date time format string is same as result.